### PR TITLE
Parse one character country code for Germany.

### DIFF
--- a/src/main/java/com/innovatrics/mrz/MrzFinderUtil.java
+++ b/src/main/java/com/innovatrics/mrz/MrzFinderUtil.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public final class MrzFinderUtil {
 
 	// MRZ First Line - Type + delimiter or code + country code (then allow for line up to 30-44 length)
-	private static final Pattern MRZFIRSTLINE = Pattern.compile("[P|V|A|C|I][A-Z0-9<][A-Z]{3}[A-Z0-9<]{25,39}");
+	private static final Pattern MRZFIRSTLINE = Pattern.compile("[P|V|A|C|I][A-Z0-9<]([A-Z]{3}|D<<)[A-Z0-9<]{25,39}");
 	// MRZ Standard Characters Line (30 to 44 length)
 	private static final Pattern MRZCHARS = Pattern.compile("[A-Z0-9<]{30,44}");
 
@@ -52,7 +52,7 @@ public final class MrzFinderUtil {
 		for (String line : lines) {
 			String test = line.trim();
 			if (found) {
-				// Only extract continuos MRZ lines
+				// Only extract continuous MRZ lines
 				if (!MRZCHARS.matcher(test).matches()) {
 					break;
 				}

--- a/src/test/java/com/innovatrics/mrz/MrzFinderUtilTest.java
+++ b/src/test/java/com/innovatrics/mrz/MrzFinderUtilTest.java
@@ -9,9 +9,12 @@ import org.junit.Test;
 public class MrzFinderUtilTest {
 
 	private static final String VALID_MRZ = "I<SVKNOVAK<<JAN<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n123456<AA5SVK8110251M1801020749313<<<<<<<<70";
+	private static final String VALID_GER_MRZ = "P<D<<MUSTERMANN<<ERIKA<<<<<<<<<<<<<<<<<<<<<<\nC01X00T478D<<6408125F2702283<<<<<<<<<<<<<<<4";
 	private static final String INVALID_MRZ = "I<SVKNOVAK<<JAN<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n123456";
 	private static final String WRAPPED_VALID = "xx\n\nyyy\n" + VALID_MRZ + "\nZZZZ";
+  private static final String WRAPPED_VALID_GER_MRZ = "xx\n\nyyy\n" + VALID_GER_MRZ + "\nZZZZ";
 	private static final String WRAPPED_INVALID_MRZ = "XX\nAZ09<\nYYY\n" + INVALID_MRZ + "\nAZ09<\nZZZZ";
+	private static final String NO_GER_MRZ = "P<DE<MUSTERMANN<<ERIKA<<<<<<<<<<<<<<<<<<<<<<\nC01X00T478D<<6408125F2702283<<<<<<<<<<<<<<<4";
 	private static final String NO_MRZ = "AZ09<\n\nBBB\n\nAZ09<\nCCCCC";
 
 	@Test
@@ -20,8 +23,18 @@ public class MrzFinderUtilTest {
 	}
 
 	@Test
+	public void testValidGerMrz() throws MrzNotFoundException, MrzParseException {
+	  Assert.assertEquals("Did not find valid MRZ", VALID_GER_MRZ, MrzFinderUtil.findMrz(VALID_GER_MRZ));
+	}
+
+	@Test
 	public void testValidWrappedMrz() throws MrzNotFoundException, MrzParseException {
 		Assert.assertEquals("Did not find valid wrapped MRZ", VALID_MRZ, MrzFinderUtil.findMrz(WRAPPED_VALID));
+	}
+
+	@Test
+	public void testValidWrappedGerMrz() throws MrzNotFoundException, MrzParseException {
+	  Assert.assertEquals("Did not find valid wrapped MRZ", VALID_GER_MRZ, MrzFinderUtil.findMrz(WRAPPED_VALID_GER_MRZ));
 	}
 
 	@Test(expected = MrzParseException.class)
@@ -38,6 +51,11 @@ public class MrzFinderUtilTest {
 	public void testNotFoundMrz() throws MrzNotFoundException, MrzParseException {
 		MrzFinderUtil.findMrz(NO_MRZ);
 	}
+
+  @Test(expected = MrzNotFoundException.class)
+  public void testNotFoundGerMrz() throws MrzNotFoundException, MrzParseException {
+    MrzFinderUtil.findMrz(NO_GER_MRZ);
+  }
 
 	@Test(expected = MrzNotFoundException.class)
 	public void testNullMrz() throws MrzNotFoundException, MrzParseException {


### PR DESCRIPTION
Germany does not use a 3-character-code but just one character.
See https://en.wikipedia.org/wiki/Machine-readable_passport#Nationality_codes_and_checksum_calculation
This prevents the MRZ from corresponding documents to be found.